### PR TITLE
Remove use of extern to allow amalgamation of all source files

### DIFF
--- a/minlzlib/lzmadec.c
+++ b/minlzlib/lzmadec.c
@@ -27,6 +27,8 @@ Environment:
 #include "minlzlib.h"
 #include "lzmadec.h"
 
+static const uint16_t k_LzmaRcHalfProbability = LZMA_RC_MAX_PROBABILITY / 2;
+
 //
 // Probability Bit Model for Lenghts in Rep and in Match sequences
 //
@@ -580,7 +582,6 @@ LzInitialize (
     uint8_t Properties
     )
 {
-    extern uint16_t k_LzmaRcHalfProbability;
     //
     // LZMA decoding uses 3 "properties" which determine how the probability
     // bit model will be laid out. These store the number of bits that are used

--- a/minlzlib/minlzlib.h
+++ b/minlzlib/minlzlib.h
@@ -52,6 +52,12 @@ bool DtCanWrite(uint32_t* Position);
 bool DtIsComplete(uint32_t* BytesProcessed);
 
 //
+// The range decoder uses 11 probability bits, where 2048 is 100% chance of a 0
+//
+#define LZMA_RC_PROBABILITY_BITS            11
+#define LZMA_RC_MAX_PROBABILITY             (1 << LZMA_RC_PROBABILITY_BITS)
+
+//
 // Range Decoder
 //
 uint8_t RcGetBitTree(uint16_t* BitModel, uint16_t Limit);

--- a/minlzlib/rangedec.c
+++ b/minlzlib/rangedec.c
@@ -35,13 +35,6 @@ Environment:
 #include "minlzlib.h"
 
 //
-// The range decoder uses 11 probability bits, where 2048 is 100% chance of a 0
-//
-#define LZMA_RC_PROBABILITY_BITS            11
-#define LZMA_RC_MAX_PROBABILITY             (1 << LZMA_RC_PROBABILITY_BITS)
-const uint16_t k_LzmaRcHalfProbability = LZMA_RC_MAX_PROBABILITY / 2;
-
-//
 // The range decoder uses an exponential moving average of the last probability
 // hit (match or miss) with an adaptation rate of 5 bits (which falls in the
 // middle of its 11 bits used to encode a probability.


### PR DESCRIPTION
For example: https://github.com/dimkr/papaw/pull/31/files#diff-56594f1db77ebf275fb6bcf0789d4e4eR89-R95.

This ability to build minlzma as a single compilation unit is useful for several reasons:
1. This makes it an alternative to https://github.com/richgel999/miniz, especially if a single-file variant is available
2. It makes it much smaller, because of compiler optimizations that don't happen across multiple compilation units